### PR TITLE
Use regexes to mask accesslog entries

### DIFF
--- a/api/envoy/config/accesslog/v2/file.proto
+++ b/api/envoy/config/accesslog/v2/file.proto
@@ -18,7 +18,15 @@ import "google/protobuf/struct.proto";
 message FileAccessLog {
   // A path to a local file to which to write the access log entries.
   string path = 1 [(validate.rules).string.min_bytes = 1];
-
+  
+  repeated LogLineMask masks = 5;
+  
+  message LogLineMask {
+    string name = 1;
+    string regex = 2;
+    string mask_with = 3;
+  }
+  
   // Access log format. Envoy supports :ref:`custom access log formats
   // <config_access_log_format>` as well as a :ref:`default format
   // <config_access_log_default_format>`.

--- a/include/envoy/access_log/access_log.h
+++ b/include/envoy/access_log/access_log.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <regex>
 
 #include "envoy/common/pure.h"
 #include "envoy/http/header_map.h"
@@ -139,5 +140,19 @@ public:
 
 using FormatterProviderPtr = std::unique_ptr<FormatterProvider>;
 
+  /**
+   * See file.proto for the definition
+   */
+class AccessLogMask {
+public:
+  AccessLogMask(const std::string& name,
+	       const std::string& regex,
+	       const std::string& replacer);
+  
+  std::string name_;
+  std::regex regex_;
+  std::string replace_with_;
+};
+  
 } // namespace AccessLog
 } // namespace Envoy

--- a/source/common/access_log/BUILD
+++ b/source/common/access_log/BUILD
@@ -32,6 +32,7 @@ envoy_cc_library(
         "//include/envoy/api:api_interface",
         "//source/common/buffer:buffer_lib",
         "//source/common/common:thread_lib",
+	"//source/common/http:utility_lib"
     ],
 )
 

--- a/source/common/access_log/access_log_manager_impl.cc
+++ b/source/common/access_log/access_log_manager_impl.cc
@@ -6,9 +6,16 @@
 #include "common/common/fmt.h"
 #include "common/common/lock_guard.h"
 #include "common/common/stack_array.h"
+#include "common/common/utility.h"
 
 namespace Envoy {
 namespace AccessLog {
+
+
+AccessLogMask::AccessLogMask(const std::string& name,
+			     const std::string& regex,
+			     const std::string& replacer)
+  : name_(name), regex_(RegexUtil::parseRegex(regex)), replace_with_(replacer) {}
 
 void AccessLogManagerImpl::reopen() {
   for (auto& access_log : access_logs_) {

--- a/source/extensions/access_loggers/file/config.cc
+++ b/source/extensions/access_loggers/file/config.cc
@@ -2,7 +2,7 @@
 
 #include <memory>
 #include <unordered_map>
-
+#include <vector>
 #include "envoy/config/accesslog/v2/file.pb.validate.h"
 #include "envoy/registry/registry.h"
 #include "envoy/server/filter_config.h"
@@ -44,8 +44,18 @@ FileAccessLogFactory::createAccessLogInstance(const Protobuf::Message& config,
         "Invalid access_log format provided. Only 'format' and 'json_format' are supported.");
   }
 
+  auto masks = fal_config.masks();
+
+  std::vector<AccessLog::AccessLogMask> parsed_masks;
+
+  for(int i=0;i<masks.size();i++) {
+    auto access_log_mask = AccessLog::AccessLogMask(masks[i].name(), masks[i].regex(),
+						    masks[i].mask_with());
+    parsed_masks.push_back(access_log_mask);
+  }
+  
   return std::make_shared<FileAccessLog>(fal_config.path(), std::move(filter), std::move(formatter),
-                                         context.accessLogManager());
+                                         context.accessLogManager(), parsed_masks);
 }
 
 ProtobufTypes::MessagePtr FileAccessLogFactory::createEmptyConfigProto() {

--- a/source/extensions/access_loggers/file/file_access_log_impl.h
+++ b/source/extensions/access_loggers/file/file_access_log_impl.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "envoy/access_log/access_log.h"
+#include <vector>
 
 namespace Envoy {
 namespace Extensions {
@@ -13,7 +14,8 @@ namespace File {
 class FileAccessLog : public AccessLog::Instance {
 public:
   FileAccessLog(const std::string& access_log_path, AccessLog::FilterPtr&& filter,
-                AccessLog::FormatterPtr&& formatter, AccessLog::AccessLogManager& log_manager);
+                AccessLog::FormatterPtr&& formatter, AccessLog::AccessLogManager& log_manager,
+                const std::vector<AccessLog::AccessLogMask>& log_line_masks = std::vector<AccessLog::AccessLogMask>());
 
   // AccessLog::Instance
   void log(const Http::HeaderMap* request_headers, const Http::HeaderMap* response_headers,
@@ -24,6 +26,7 @@ private:
   AccessLog::AccessLogFileSharedPtr log_file_;
   AccessLog::FilterPtr filter_;
   AccessLog::FormatterPtr formatter_;
+  std::vector<AccessLog::AccessLogMask> log_line_masks_;
 };
 
 } // namespace File


### PR DESCRIPTION
* Implemented regex access log masking for file access logs.

Description: For the file based access logger, apply a series of regex replaces. This will be used to sanitze logs in case where it could contain sensitive information.

`api/envoy/config/accesslog/v2/file.proto` has been changed to accept log line masks.

Risk Level: Medium

Testing: Unit tests pending, benchmarking / perf testing not done.

Docs Changes: None

Release Notes:

[Optional Fixes #Issue]
[Optional Deprecated:]
